### PR TITLE
Declare JettyResourceHandler as open

### DIFF
--- a/src/main/java/io/javalin/staticfiles/JettyResourceHandler.kt
+++ b/src/main/java/io/javalin/staticfiles/JettyResourceHandler.kt
@@ -20,7 +20,7 @@ import javax.servlet.http.HttpServletResponse
 data class StaticFileConfig(val path: String, val location: Location)
 enum class Location { CLASSPATH, EXTERNAL; }
 
-class JettyResourceHandler(staticFileConfig: Set<StaticFileConfig>, jettyServer: Server, private val ignoreTrailingSlashes: Boolean) {
+open class JettyResourceHandler(staticFileConfig: Set<StaticFileConfig>, jettyServer: Server, private val ignoreTrailingSlashes: Boolean) {
 
     private val log = LoggerFactory.getLogger("io.javalin.Javalin")
 
@@ -55,7 +55,7 @@ class JettyResourceHandler(staticFileConfig: Set<StaticFileConfig>, jettyServer:
         return staticFileConfig.path
     }
 
-    fun handle(httpRequest: HttpServletRequest, httpResponse: HttpServletResponse): Boolean {
+    open fun handle(httpRequest: HttpServletRequest, httpResponse: HttpServletResponse): Boolean {
         val target = httpRequest.getAttribute("jetty-target") as String
         val baseRequest = httpRequest.getAttribute("jetty-request") as Request
         for (gzipHandler in handlers) {


### PR DESCRIPTION
Declare JettyResourceHandler and handle method as open to allow extending through inheritance.